### PR TITLE
PATCH: Better error handling around bad credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # changelog
-## v1.2
-	Utilizes Dockerfile and requirements.txt to get all dependencies
-## v1.1
-	Removed debug and commented code
-	Refactored logging functionality into its own class to be utilized by multiple modules
-	Log file created is based upon filename used
-## v1.0
-	Initial code push
+### v0.4
+--------
+* RENUMBERED VERSIONS to match the [Semantic Versioning 2.0.0 standard](https://semver.org/)
+** Previous version names were v1.0-v1.2
+* Added in a "Credentials Check" before actually running through the CSV file, which causes the script to exit on an error.
+** This check makes sure that the specified credentials can be used to successfully call getmaintenancescheduleinfo.do
+* Improved overall error-trapping throughout bulkupload.py and new_api.py
+### v0.3
+--------
+* Utilizes Dockerfile and requirements.txt to get all dependencies
+### v0.2
+--------
+* Removed debug and commented code
+* Refactored logging functionality into its own class to be utilized by multiple modules
+* Log file created is based upon filename used
+### v0.1
+--------
+* Initial code push

--- a/new_api.py
+++ b/new_api.py
@@ -1,4 +1,4 @@
-import requests, sys, os, json, logging, logger
+import requests, logger
 import xml.etree.ElementTree as ET
 from veracode_api_signing.plugin_requests import RequestsAuthPluginVeracodeHMAC as VeracodeHMAC
 
@@ -9,23 +9,18 @@ class veracode_api_call():
 		try: self.rownum = 'Line #%s' % (params.pop('rownum'))
 		except: self.rownum = 'TEST'
 
-		self.url, self.response_type = self.get_url_from_endpoint(endpoint)
+		self.url = self.get_url_from_endpoint(endpoint)
 
 		if creds == None:
 			self.auth=VeracodeHMAC(profile = None)
 		else: self.auth=(creds)
 
 		self.r = requests.get(url=self.url, auth=self.auth, params=params)
-		
-		if self.response_type == 'json':
-			self.response = json.loads( str( self.r.text ) )
-		else:
-			self.response = ET.fromstring( self.r.text )
 
 		self.log_activity()
 
 	def get_url_from_endpoint(self, endpoint):
-		version_numbers = dict(beginprescan='5.0', beginscan='5.0', createapp='4.0', \
+		xml_version_numbers = dict(beginprescan='5.0', beginscan='5.0', createapp='4.0', \
 			createbuild='4.0', deleteapp='5.0', deletebuild='5.0', getappinfo='5.0', \
 			getapplist='5.0', getbuildinfo='5.0', getbuildlist='5.0', getfilelist='5.0', \
 			getpolicylist='5.0', getprescanresults='5.0', getvendorlist='5.0', \
@@ -39,16 +34,32 @@ class veracode_api_call():
 			getteamlist='3.0', updateteam='3.0', getcurriculumlist='3.0', gettracklist='3.0', \
 			getmaintenancescheduleinfo='3.0', generateflawreport='3.0', downloadflawreport='3.0')
 
-		if endpoint in version_numbers:
-			return '%s/%s/%s.do' % ('https://analysiscenter.veracode.com/api', version_numbers[endpoint], endpoint), 'xml'
-
+		if endpoint in xml_version_numbers:
+			return '%s/%s/%s.do' % ('https://analysiscenter.veracode.com/api', xml_version_numbers[endpoint], endpoint)
 		else:
-			return '%s/%s' % ('https://api.veracode.io/elearning/v1/', endpoint), 'json'
-
-	def get_response(self): return self.response
+			return '%s/%s' % ('https://api.veracode.io/elearning/v1/', endpoint)
 
 	def log_activity(self):
-		if self.response.tag == 'error':
-			self.logger.error( "[{0}]{1}".format(self.rownum, self.response.text) )
+		self.r.raise_for_status()
+		if self.r.status_code == 401:
+			self.logger.error( "[{0}]{1}".format(self.rownum, "401 Unauthorized") )
+		elif 'text/xml' in self.r.headers.get('content-type'):
+			response = ET.fromstring(self.r.content)
+			if response.tag == 'error':
+				self.logger.error( "[{0}]{1}".format(self.rownum, response.text) )
+			else:
+				self.logger.info( "[{0}]{1}".format(self.rownum, 'Success')	)
+		elif 'application/json' in self.r.headers.get('content-type'):
+			self.logger.info( "[{0}]{1}".format(self.rownum, 'Unsure how to process JSON') )
 		else:
-			self.logger.info( "[{0}]{1}".format(self.rownum, 'Success')	)
+			self.logger.info( "[{0}]{1}".format(self.rownum, 'Unsure how to process response') )
+
+	def print_response_info(self):
+		print '>>> r.status_code'
+		print self.r.status_code
+		print '>>> r.encoding'
+		print self.r.encoding
+		print ">>> r.headers.get('content-type')"
+		print self.r.headers.get('content-type')
+		print '>>> r.text'
+		print str(self.r.text)


### PR DESCRIPTION
Code update for #5.

* Changed `bulkupload.py` to do a check for valid credentials by calling `/3.0/getmaintenancescheduleinfo.do` before actually iterating through the CSV file. If `raise_for_status()` notices a bad response code then the script will exit.
* Changed `new_api.py` to not parse the response ahead of time. It now chooses a parsing mechanism based upon the detected content-type of the response.
* Need a proper parsing mechanism for JSON responses. This wasn't prioritized since the JSON REST API endpoints aren't frequently used (created #9).